### PR TITLE
swap other person previous registration radio button order

### DIFF
--- a/arc_application/forms/form.py
+++ b/arc_application/forms/form.py
@@ -957,8 +957,8 @@ class OtherPersonPreviousRegistrationDetailsForm(GOVUKForm):
     reveal_conditionally = {'previous_registration': {True: 'individual_id'}}
 
     choices = (
+        (True, 'Yes'),
         (False, 'No'),
-        (True, 'Yes')
     )
 
     previous_registration = forms.ChoiceField(choices=choices, label='Has the person previously registered with Ofsted?',


### PR DESCRIPTION
## Description

As per kashif's comment on [CCN3-1138], the other person registration details radio buttons should be swapped in order.

## Todo's before PR

- [x] Rebase from develop
- [x] Unit tests passed (`make test`)
- [x] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates been checked with relevant user-story

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assigneses (those who'll merge)
- [x] Specified labels
- [x] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
