### PR TITLE
fix/CCN3-1512/remove-personal-details-flags

### DIFF
--- a/arc_application/forms/form.py
+++ b/arc_application/forms/form.py
@@ -33,44 +33,6 @@ class LogInDetailsForm(GOVUKForm):
     auto_replace_widgets = True
     field_label_classes = 'form-label-bold'
 
-    email_address_declare = forms.BooleanField(label='This information is correct',
-                                               widget=custom_field_widgets.CustomCheckboxInput(), required=False)
-    email_address_comments = forms.CharField(label='Enter your reasoning', help_text='(Tip: be clear and concise)',
-                                             widget=custom_field_widgets.Textarea(attrs={'cols': '40', 'rows': '3'}),
-                                             required=False)
-    mobile_number_declare = forms.BooleanField(label='This information is correct',
-                                               widget=custom_field_widgets.CustomCheckboxInput, required=False)
-    mobile_number_comments = forms.CharField(label='Enter your reasoning', help_text='(Tip: be clear and concise)',
-                                             widget=custom_field_widgets.Textarea, required=False)
-    add_phone_number_declare = forms.BooleanField(label='This information is correct',
-                                                  widget=custom_field_widgets.CustomCheckboxInput,
-                                                  required=False)
-    add_phone_number_comments = forms.CharField(label='Enter your reasoning', help_text='(Tip: be clear and concise)',
-                                                widget=custom_field_widgets.Textarea, required=False)
-    security_question_declare = forms.BooleanField(label='This information is correct',
-                                                   widget=custom_field_widgets.CustomCheckboxInput,
-                                                   required=False)
-    security_question_comments = forms.CharField(label='Enter your reasoning', help_text='(Tip: be clear and concise)',
-                                                 widget=custom_field_widgets.Textarea, required=False)
-    security_answer_declare = forms.BooleanField(label='This information is correct',
-                                                 widget=custom_field_widgets.CustomCheckboxInput, required=False)
-    security_answer_comments = forms.CharField(label='Enter your reasoning', help_text='(Tip: be clear and concise)',
-                                               widget=custom_field_widgets.Textarea, required=False)
-
-    # As this will only happen once per page, we can do this in the form itself rather than __init
-    # Each checkbox must be assigned a name for the html injection
-    checkboxes = [(email_address_declare, 'email_address'), (mobile_number_declare, 'mobile_number'),
-                  (add_phone_number_declare, 'add_phone_number'),
-                  (security_question_declare, 'security_question'),
-                  (security_answer_declare, 'security_answer')]
-
-    # This is where the html is added that assigns each checkbox with the correct name, so the javascript knows where
-    # act
-    for box in checkboxes:
-        box[0].widget.attrs.update({'data_target': box[1],
-                                    'aria-controls': box[1],
-                                    'aria-expanded': 'false'}, )
-
     def __init__(self, *args, **kwargs):
         self.table_keys = kwargs.pop('table_keys')
         super(LogInDetailsForm, self).__init__(*args, **kwargs)

--- a/arc_application/templates/contact-summary.html
+++ b/arc_application/templates/contact-summary.html
@@ -24,9 +24,6 @@
             <td style="word-wrap: break-word">
                 {{email}}
             </td>
-            <td class="change-answer">
-                {{ form.email_address_declare }}
-            </td>
         </tr>
         <tr class="js-hidden" id="email_address">
             <td colspan="1">
@@ -47,9 +44,6 @@
             </td>
             <td style="word-wrap: break-word">
                 {{mobile_number}}
-            </td>
-            <td class="change-answer">
-                {{ form.mobile_number_declare }}
             </td>
         </tr>
         <tr class="js-hidden" id="mobile_number">
@@ -73,9 +67,6 @@
             </td>
             <td style="word-wrap: break-word">
                 {{add_phone_number}}
-            </td>
-            <td class="change-answer">
-                {{ form.add_phone_number_declare }}
             </td>
         </tr>
         <tr class="js-hidden" id="add_phone_number">

--- a/arc_application/tests/tests.py
+++ b/arc_application/tests/tests.py
@@ -241,48 +241,6 @@ class ArcSummaryTest(TestCase):
         self.assertEqual(resp.url, '/arc/summary')
         self.assertEqual(resp.status_code, 302)
 
-    def test_task_flagged_with_comment_login_details(self):
-        # Assemble
-        create_application()
-
-        post_dictionary = {
-            'id': application.application_id,
-            'mobile_number_declare': True,
-            'mobile_number_comments': 'There was a test issue with this field'
-        }
-
-        # Act
-        self.client.login(username='arc_test', password='my_secret')
-
-        response = self.client.post(reverse('contact_summary'), post_dictionary)
-
-        # Assert
-
-        # 1. Check HTTP status code correct
-        self.assertEqual(response.status_code, 302)
-
-        # 2. Ensure overall task status marked as FLAGGED in ARC view
-        reloaded_arc_record = Arc.objects.get(pk=application.application_id)
-        self.assertEqual(reloaded_arc_record.login_details_review, flagged_status)
-
-        # 3. Check that comment has been correctly appended to application
-        try:
-            arc_comments = ArcComments.objects.get(
-                table_pk='8362d470-ecc9-4069-876b-9b3ddc2cae07',
-                table_name='USER_DETAILS',
-                field_name='mobile_number',
-                comment='There was a test issue with this field',
-                flagged=True,
-            )
-        except:
-            self.fail('ARC comment could not be retrieved for flagged field')
-
-        self.assertIsNotNone(arc_comments)
-
-        # 4. Check flagged boolean indicator is set on the application record
-        reloaded_application = Application.objects.get(pk=application.application_id)
-        self.assertTrue(reloaded_application.login_details_arc_flagged)
-
     def test_task_flagged_with_comment_personal_details(self):
         # Assemble
         create_application()

--- a/arc_application/views/arc_summary.py
+++ b/arc_application/views/arc_summary.py
@@ -19,9 +19,9 @@ ordered_models = [UserDetails, ChildcareType, [ApplicantPersonalDetails, Applica
                   FirstAidTraining, EYFS, HealthDeclarationBooklet, CriminalRecordCheck, Application,
                   AdultInHome, ChildInHome, Reference]
 
-name_field_dict = {'Your email': 'email_address',
-                   'Your mobile number': 'mobile_number',
-                   'Other phone number': 'add_phone_number',
+name_field_dict = {'Your email': None,
+                   'Your mobile number': None,
+                   'Other phone number': None,
                    'Looking after 0 to 5 year olds?': None,
                    'Looking after 5 to 7 year olds? ': None,
                    'Looking after 8 year olds and older? ': None,

--- a/arc_application/views/contact_details.py
+++ b/arc_application/views/contact_details.py
@@ -38,33 +38,14 @@ def contact_summary(request):
         form = LogInDetailsForm(request.POST, table_keys=[login_id])
 
         if form.is_valid():
-            # Convert the data from the form into a series of comments with the
-            # table id to be stored in the ARC COMMENTS Table
-            comment_list = request_to_comment(login_id, table_name, form.cleaned_data)
-            save_successful = save_comments(request, comment_list)
 
-            # If no comments have been made, the status has not been flagged
-            # Therefore it has been completed
-            if not comment_list:
-                section_status = 'COMPLETED'
-                application.login_details_arc_flagged = False
-            else:
-                section_status = 'FLAGGED'
-                application.login_details_arc_flagged = True
+            status = Arc.objects.get(pk=application_id_local)
+            status.login_details_review = 'COMPLETED'
+            status.save()
+            default = '/childcare/age-groups'
+            redirect_link = redirect_selection(request, default)
 
-            application.save()
-
-            # If the save has been successful , save and redirect
-            if save_successful:
-                status = Arc.objects.get(pk=application_id_local)
-                status.login_details_review = section_status
-                status.save()
-                default = '/childcare/age-groups'
-                redirect_link = redirect_selection(request, default)
-
-                return HttpResponseRedirect(settings.URL_PREFIX + redirect_link + '?id=' + application_id_local)
-            else:
-                return ChildProcessError
+            return HttpResponseRedirect(settings.URL_PREFIX + redirect_link + '?id=' + application_id_local)
 
     application = Application.objects.get(pk=application_id_local)
     user_details = UserDetails.objects.get(application_id=application)


### PR DESCRIPTION
## Description

Removed flagging functionality from personal details, specifically:
- Removed related fields from form, also removed outdated fields for "security questions".
- Removed checkbox tags from the relevant template.
- Updated arc_summary to not show personal details flags.

## Todo's before PR

- [x] Rebase from develop
- [x] Unit tests passed (`make test`)
- [x] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates been checked with relevant user-story

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assigneses (those who'll merge)
- [x] Specified labels
- [x] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
