### PR TITLE
Fix/CCN3-1378/search-two-chars

### DIFF
--- a/arc_application/forms/childminder_forms/form.py
+++ b/arc_application/forms/childminder_forms/form.py
@@ -591,7 +591,7 @@ class SearchForm(GOVUKForm):
         if len(reference) != 0 and len(reference) < 3:
             self.add_error('reference_search_field', length_error_text)
 
-        if len(name) != 0 and len(name) < 3:
+        if len(name) != 0 and len(name) < 2:
             self.add_error('name_search_field', length_error_text)
 
         if len(dob) != 0 and len(dob) < 3:

--- a/arc_application/forms/childminder_forms/form.py
+++ b/arc_application/forms/childminder_forms/form.py
@@ -587,7 +587,7 @@ class SearchForm(GOVUKForm):
         reference = self.cleaned_data['reference_search_field']
 
         length_error_text = 'Please enter more than 2 characters'
-        name_length_error_text = 'Please enter more than 1 character -TBC'
+        name_length_error_text = 'Please enter more than one character'
 
         if len(reference) != 0 and len(reference) < 3:
             self.add_error('reference_search_field', length_error_text)

--- a/arc_application/forms/childminder_forms/form.py
+++ b/arc_application/forms/childminder_forms/form.py
@@ -587,12 +587,13 @@ class SearchForm(GOVUKForm):
         reference = self.cleaned_data['reference_search_field']
 
         length_error_text = 'Please enter more than 2 characters'
+        name_length_error_text = 'Please enter more than 1 character -TBC'
 
         if len(reference) != 0 and len(reference) < 3:
             self.add_error('reference_search_field', length_error_text)
 
         if len(name) != 0 and len(name) < 2:
-            self.add_error('name_search_field', length_error_text)
+            self.add_error('name_search_field', name_length_error_text)
 
         if len(dob) != 0 and len(dob) < 3:
             self.add_error('dob_search_field', length_error_text)


### PR DESCRIPTION
## Description

Updated form to allow 2 characters.
Updated error message content to reflect this change.

## Todo's before PR

- [x] Rebase from develop
- [x] Unit tests passed (`make test`)
- [x] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates been checked with relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assigneses (those who'll merge)
- [x] Specified labels
- [x] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
