### PR TITLE
Trello bug 120 fix: Fix propagation of child address flags to master summary page

### DIFF
--- a/arc_application/forms/form.py
+++ b/arc_application/forms/form.py
@@ -1188,55 +1188,55 @@ class ChildAddressForm(GOVUKForm):
     Form for handling user responses where their children address have been detailed
     """
 
-    address_declare = forms.BooleanField(label='This information is correct',
+    child_address_declare = forms.BooleanField(label='This information is correct',
                                          widget=custom_field_widgets.CustomCheckboxInput, required=False)
-    address_comments = forms.CharField(label='Address', help_text='(Tip: be clear and concise)',
+    child_address_comments = forms.CharField(label='Address', help_text='(Tip: be clear and concise)',
                                        widget=custom_field_widgets.Textarea,
                                        required=False, max_length=250)
 
     instance_id = forms.CharField(widget=forms.HiddenInput, required=False)
 
-    def clean_address_comments(self):
+    def clean_child_address_comments(self):
         """
         Address comments validation
         :return: string
         """
-        address_declare = self.cleaned_data['address_declare']
-        address_comments = self.cleaned_data['address_comments']
+        child_address_declare = self.cleaned_data['child_address_declare']
+        child_address_comments = self.cleaned_data['child_address_comments']
 
         # Only check if a comment has been entered if the field has been flagged
-        if address_declare is True:
-            if address_comments == '':
+        if child_address_declare is True:
+            if child_address_comments == '':
                 raise forms.ValidationError('You must give reasons')
 
-        return address_comments
+        return child_address_comments
 
     def __init__(self, *args, **kwargs):
         super(ChildAddressForm, self).__init__(*args, **kwargs)
         id_value = str(uuid.uuid4())
         self.fields['instance_id'].initial = id_value
 
-        checkboxes = [((self.fields['address_declare']), 'address' + id_value)]
+        checkboxes = [((self.fields['child_address_declare']), 'child_address' + id_value)]
 
         for box in checkboxes:
             box[0].widget.attrs.update({'data_target': box[1],
                                         'aria-controls': box[1],
                                         'aria-expanded': 'false'}, )
 
-    def clean_address_comments(self):
+    def clean_child_address_comments(self):
         """
         Address comments validation
         :return: string
         """
-        address_declare = self.cleaned_data['address_declare']
-        address_comments = self.cleaned_data['address_comments']
+        child_address_declare = self.cleaned_data['child_address_declare']
+        child_address_comments = self.cleaned_data['child_address_comments']
 
         # Only check if a comment has been entered if the field has been flagged
-        if address_declare is True:
-            if address_comments == '':
+        if child_address_declare is True:
+            if child_address_comments == '':
                 raise forms.ValidationError('You must give reasons')
 
-        return address_comments
+        return child_address_comments
 
 
 class ChildForm(GOVUKForm):

--- a/arc_application/forms/form.py
+++ b/arc_application/forms/form.py
@@ -1223,21 +1223,6 @@ class ChildAddressForm(GOVUKForm):
                                         'aria-controls': box[1],
                                         'aria-expanded': 'false'}, )
 
-    def clean_child_address_comments(self):
-        """
-        Address comments validation
-        :return: string
-        """
-        child_address_declare = self.cleaned_data['child_address_declare']
-        child_address_comments = self.cleaned_data['child_address_comments']
-
-        # Only check if a comment has been entered if the field has been flagged
-        if child_address_declare is True:
-            if child_address_comments == '':
-                raise forms.ValidationError('You must give reasons')
-
-        return child_address_comments
-
 
 class ChildForm(GOVUKForm):
     """

--- a/arc_application/templates/your-children-summary.html
+++ b/arc_application/templates/your-children-summary.html
@@ -163,21 +163,21 @@
                     {{child_address.postcode}}{% if address.postcode %}<br />{% endif %}
                 </td>
                 <td class="change-answer">
-                    {{ child_address_form.address_declare }}
+                    {{ child_address_form.child_address_declare }}
                 </td>
             </tr>
-            <tr class="js-hidden" id="address{{child_address_form.instance_id.initial}}">
+            <tr class="js-hidden" id="child_address{{child_address_form.instance_id.initial}}">
                 <td colspan="1">
                     <div>
                         Enter your reasoning
                     </div>
                     <div>
-                        {{ child_address_form.address_comments.help_text}}
+                        {{ child_address_form.child_address_comments.help_text}}
                     </div>
                 </td>
                 <td colspan="2">
                     <div>
-                        {{ child_address_form.address_comments}}
+                        {{ child_address_form.child_address_comments}}
                     </div>
                 </td>
             </tr>

--- a/arc_application/views/arc_summary.py
+++ b/arc_application/views/arc_summary.py
@@ -57,7 +57,7 @@ name_field_dict = {
     'Have you lived or worked on a British military base outside of the UK in the last 5 years?': 'military_base',
     'Do you have an Ofsted DBS Check?': 'capita',
     'Are you on the DBS update service?': 'on_update',
-    'Which of your children live with you?': 'children_living_with_you'
+    'Which of your children live with you?': 'children_living_with_childminder_selection'
 }
 
 

--- a/arc_application/views/arc_summary.py
+++ b/arc_application/views/arc_summary.py
@@ -42,13 +42,14 @@ name_field_dict = {
     'Name': 'full_name',
     'Date of birth': 'date_of_birth',
     'Relationship': 'relationship',
-    'Email': 'email_address',
+    'Email': 'email',
     'Does anyone aged 16 or over live or work in your home?': 'adults_in_home',
-    'Do you live with any children?': 'children_in_home',
+    'Do children under 16 live in the home?': 'children_in_home',
+    'Do you have children of your own under 16 who do not live with you?': 'own_children_not_in_home',
     'Full name': 'full_name',
     'How they know you': 'relationship',
     'Known for': 'time_known',
-    'Address': 'address',
+    'address': 'address',
     'Phone number': 'phone_number',
     'Email address': 'email_address',
     'What type of childcare training have you completed?': 'childcare_training',
@@ -174,6 +175,12 @@ def add_comments(json, app_id):
                         field = name_field_dict.get('eyfs_course_date', '')
                     elif "First aid" in title:
                         field = name_field_dict.get('first_aid_date', '')
+
+                elif name == 'Address':
+                    if "reference" in title:
+                        field = name_field_dict.get('address', '')
+                    else:
+                        field = 'address' + str(id)
 
                 else:
                     field = name_field_dict.get(name, '')

--- a/arc_application/views/arc_summary.py
+++ b/arc_application/views/arc_summary.py
@@ -38,11 +38,11 @@ name_field_dict = {
     'Provide a Health Declaration Booklet?': 'health_submission_consent',
     'DBS certificate number': 'dbs_certificate_number',
     'Do you have any criminal cautions or convictions?': 'cautions_convictions',
-    'Health check status': 'health_check_status',
+    'Health questions status': 'health_check_status',
     'Name': 'full_name',
     'Date of birth': 'date_of_birth',
     'Relationship': 'relationship',
-    'Email': 'email',
+    'Email': 'email_address',
     'Does anyone aged 16 or over live or work in your home?': 'adults_in_home',
     'Do you live with any children?': 'children_in_home',
     'Full name': 'full_name',
@@ -53,9 +53,10 @@ name_field_dict = {
     'Email address': 'email_address',
     'What type of childcare training have you completed?': 'childcare_training',
     'Have you lived outside of the UK in the last 5 years?': 'lived_abroad',
-    'Have you lived or worked on a British military base in the last 5 years?': 'military_base',
+    'Have you lived or worked on a British military base outside of the UK in the last 5 years?': 'military_base',
     'Do you have an Ofsted DBS Check?': 'capita',
-    'Are you on the DBS update service?': 'on_update'
+    'Are you on the DBS update service?': 'on_update',
+    'Which of your children live with you?': 'children_living_with_you'
 }
 
 

--- a/arc_application/views/arc_summary.py
+++ b/arc_application/views/arc_summary.py
@@ -46,10 +46,12 @@ name_field_dict = {
     'Does anyone aged 16 or over live or work in your home?': 'adults_in_home',
     'Do children under 16 live in the home?': 'children_in_home',
     'Do you have children of your own under 16 who do not live with you?': 'own_children_not_in_home',
+    'child_address': 'child_address',
     'Full name': 'full_name',
     'How they know you': 'relationship',
     'Known for': 'time_known',
     'address': 'address',
+    'Address': 'child_address',
     'Phone number': 'phone_number',
     'Email address': 'email_address',
     'What type of childcare training have you completed?': 'childcare_training',
@@ -179,8 +181,6 @@ def add_comments(json, app_id):
                 elif name == 'Address':
                     if "reference" in title:
                         field = name_field_dict.get('address', '')
-                    else:
-                        field = 'address' + str(id)
 
                 else:
                     field = name_field_dict.get(name, '')

--- a/arc_application/views/arc_summary.py
+++ b/arc_application/views/arc_summary.py
@@ -46,7 +46,6 @@ name_field_dict = {
     'Does anyone aged 16 or over live or work in your home?': 'adults_in_home',
     'Do children under 16 live in the home?': 'children_in_home',
     'Do you have children of your own under 16 who do not live with you?': 'own_children_not_in_home',
-    'child_address': 'child_address',
     'Full name': 'full_name',
     'How they know you': 'relationship',
     'Known for': 'time_known',

--- a/arc_application/views/other_people_in_home.py
+++ b/arc_application/views/other_people_in_home.py
@@ -77,7 +77,8 @@ def other_people_summary(request):
     providing_care_in_own_home = home_address.childcare_address
 
     # Own children not in the home
-    own_children = Child.objects.filter(application_id=application_id_local).order_by('child')
+    own_children = Child.objects.filter(application_id=application_id_local, lives_with_childminder=False).order_by(
+        'child')
     own_child_name_list = []
     own_child_address_list = [
         ChildAddress.objects.get(application_id=application_id_local, child=child.child) for child in own_children
@@ -144,10 +145,12 @@ def other_people_summary(request):
 
         # Zips the formset into the list of adults
         # Converts it to a list, there was trouble parsing the form objects when it was in a zip object
-        adult_lists = list(zip(adult_record_list, adult_id_list, adult_health_check_status_list, adult_name_list, adult_birth_day_list,
-                               adult_birth_month_list, adult_birth_year_list, adult_relationship_list, adult_dbs_list, adult_lived_abroad,
-                               adult_military_base, adult_capita_dbs,
-                               formset_adult, current_illnesses, serious_illnesses, hospital_admissions))
+        adult_lists = list(
+            zip(adult_record_list, adult_id_list, adult_health_check_status_list, adult_name_list, adult_birth_day_list,
+                adult_birth_month_list, adult_birth_year_list, adult_relationship_list, adult_dbs_list,
+                adult_lived_abroad,
+                adult_military_base, adult_capita_dbs,
+                formset_adult, current_illnesses, serious_illnesses, hospital_admissions))
 
         initial_child_data = other_people_initial_population(False, children)
 
@@ -161,7 +164,8 @@ def other_people_summary(request):
 
         formset_own_child = ChildNotInHomeFormSet(initial=initial_own_child_data, prefix='own_child_not_in_home')
 
-        formset_own_child_address = ChildNotInHomeAddressFormSet(initial=children_address_initial_population(own_child_address_list), prefix='own_child_not_in_home_address')
+        formset_own_child_address = ChildNotInHomeAddressFormSet(
+            initial=children_address_initial_population(own_child_address_list), prefix='own_child_not_in_home_address')
 
         own_child_lists = zip(own_children, own_child_address_list, formset_own_child, formset_own_child_address)
 
@@ -190,7 +194,8 @@ def other_people_summary(request):
         own_child_formset = ChildNotInHomeFormSet(request.POST, prefix='own_child_not_in_home')
         own_child_address_formset = ChildNotInHomeAddressFormSet(request.POST, prefix='own_child_not_in_home_address')
 
-        if all([form.is_valid(), child_formset.is_valid(), adult_formset.is_valid(), own_child_formset.is_valid(), own_child_address_formset.is_valid()]):
+        if all([form.is_valid(), child_formset.is_valid(), adult_formset.is_valid(), own_child_formset.is_valid(),
+                own_child_address_formset.is_valid()]):
             child_data_list = child_formset.cleaned_data
             adult_data_list = adult_formset.cleaned_data
             own_child_data_list = own_child_formset.cleaned_data
@@ -223,7 +228,7 @@ def other_people_summary(request):
             # Only add comments for own_children_not_in_home if questions are applicable.
             if providing_care_in_own_home:
                 review_sections_to_process.update(
-                        {
+                    {
                         'own_children_not_in_home': {
                             'POST_data': own_child_data_list,
                             'models': own_children
@@ -288,7 +293,8 @@ def other_people_summary(request):
             for child_form, child_name in zip(child_formset, child_name_list):
                 child_form.error_summary_title = 'There was a problem (' + child_name + ')'
 
-            for child_form, child_address_form, child_name in zip(own_child_formset, own_child_address_formset, own_child_name_list):
+            for child_form, child_address_form, child_name in zip(own_child_formset, own_child_address_formset,
+                                                                  own_child_name_list):
                 child_form.error_summary_title = 'There was a problem (' + child_name + ')'
                 child_address_form.error_summary_title = 'There was a problem (' + child_name + ')'
 

--- a/arc_application/views/your_children.py
+++ b/arc_application/views/your_children.py
@@ -59,8 +59,7 @@ def __build_summary_form_data(application_id):
 
     applicant = ApplicantPersonalDetails.get_id(app_id=application_id)
     applicant_personal_address = \
-        ApplicantHomeAddress.objects.get(personal_detail_id=applicant,
-                                                                       current_address=True)
+        ApplicantHomeAddress.objects.get(personal_detail_id=applicant, current_address=True)
 
     # Create address tables
     for child in children:


### PR DESCRIPTION
## Description

- Fixed the propagation of child address flags to master summary page

## Todo's before PR

- [x] Rebase from develop
- [x] Unit tests passed (`make test`)
- [x] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates been checked with relevant user-story

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels
- [x] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
