### PR TITLE
fix/CCN3-1825/Fixing-bug-with-ARC-your-children-task

### DIFF
--- a/arc_application/views/nanny_views/nanny_form_view.py
+++ b/arc_application/views/nanny_views/nanny_form_view.py
@@ -36,7 +36,7 @@ class NannyARCFormView(FormView):
         else:
             self.handle_post_data(self.form_class)
 
-        return HttpResponseRedirect(build_url(self.success_url, get={'id': self.application_id}))
+        return HttpResponseRedirect(build_url(self.get_success_url(), get={'id': self.application_id}))
 
     def handle_post_data(self, form):
         # Write ArcComments to db from form.

--- a/arc_application/views/nanny_views/nanny_personal_details.py
+++ b/arc_application/views/nanny_views/nanny_personal_details.py
@@ -127,15 +127,6 @@ class NannyPersonalDetailsSummary(NannyARCFormView):
 
         return context
 
-    def post(self, request, *args, **kwargs):
-        self.application_id = request.GET['id']
-
-        if isinstance(self.form_class, list):
-            for form in self.form_class:
-                self.handle_post_data(form)
-        else:
-            self.handle_post_data(self.form_class)
-
     def get_success_url(self):
         self.application_id = self.request.GET['id']
 
@@ -145,8 +136,8 @@ class NannyPersonalDetailsSummary(NannyARCFormView):
 
         # If there is a record of a child within the model, link to the 'your children' task
         if show_your_children:
-            return build_url('nanny_your_children_summary', get={'id': self.application_id})
+            return 'nanny_your_children_summary'
 
         # If there are no children, link to the childcare address feature
         else:
-            return build_url('nanny_childcare_address_summary', get={'id': self.application_id})
+            return 'nanny_childcare_address_summary'


### PR DESCRIPTION
## Description

Overwritten the 'get_success_url' method within the personal details review summary page so that the reviewer is is presented with:
* the 'Childcare addresses' task if the applicant **does not** have their own children
* the 'Your children' task if the applicant **does** have children of their own

## Todo's before PR

- [ ] Rebase from develop
- [x] Unit tests passed (`make test`)
- [ ] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates been checked with relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [x] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assigneses (those who'll merge)
- [x] Specified labels
- [x] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
