### PR TITLE
fix/remove-nannies-for-release

### DIFF
--- a/arc_application/services/db_gateways.py
+++ b/arc_application/services/db_gateways.py
@@ -143,7 +143,7 @@ class IdentityGatewayActions(DBGatewayActions):
         'summary': 'application_id'
     }
 
-    target_url_prefix = os.environ.get('APP_IDENTITY_URL') + 'api/v1/'
+    # target_url_prefix = os.environ.get('APP_IDENTITY_URL') + 'api/v1/'
 
 
 class NannyGatewayActions(DBGatewayActions):
@@ -168,4 +168,4 @@ class NannyGatewayActions(DBGatewayActions):
         'timeline-log': 'object_id'
     }
 
-    target_url_prefix = os.environ.get('APP_NANNY_GATEWAY_URL') + '/api/v1/'
+    # target_url_prefix = os.environ.get('APP_NANNY_GATEWAY_URL') + '/api/v1/'

--- a/arc_application/templates/arc_user_summary.html
+++ b/arc_application/templates/arc_user_summary.html
@@ -23,10 +23,7 @@
 <p>Review a new application:</p>
 <form action="" method="post">
     {% csrf_token %}
-    <input name='add_nanny_application' type="submit" class="button" value="Add nanny application" alt='Add nanny application'>
-    <br>
-    <br>
-    <input name='add_childminder_application' type="submit" class="button" value="Add childminder application" alt='Add childminder application'>
+    <input name='add_childminder_application' type="submit" class="button" value="Add application" alt='Add childminder application'>
 </form>
 <div class="top-padded">
     {% if empty != "true" %}
@@ -51,9 +48,7 @@
             <td class="col-xs-1">{{ entry.last_accessed}}</td>
             <td class="col-xs-4">
 
-                {% if entry.app_type == 'Nanny' %}
-                <a href="{% url 'nanny_task_list' %}?id={{entry.application_id}}">
-                {% elif entry.app_type == 'Childminder' %}
+                {% if entry.app_type == 'Childminder' %}
                 <a href="{% url 'task_list' %}?id={{entry.application_id}}">
                 {% else %}
                 <a href="{% url 'task_list' %}/404">

--- a/arc_application/tests/test_arc_user_summary.py
+++ b/arc_application/tests/test_arc_user_summary.py
@@ -133,6 +133,7 @@ class ArcUserSummaryPageTests(TestCase):
 
     @tag('http')
     def test_page_renders_with_error_if_no_nanny_apps_available(self):
+        self.skipTest('Nannies temporarily removed from ARC.')
         with mock.patch('arc_application.services.db_gateways.NannyGatewayActions.list') as mock_nanny_list:
 
             mock_nanny_list.return_value.status_code = 404
@@ -163,6 +164,7 @@ class ArcUserSummaryPageTests(TestCase):
 
     @tag('http')
     def test_assigns_nanny_app_if_one_available(self):
+        self.skipTest('Nannies temporarily removed from ARC.')
         with mock.patch('arc_application.services.db_gateways.NannyGatewayActions.list') as mock_nanny_list, \
                 mock.patch('arc_application.services.db_gateways.NannyGatewayActions.read') as mock_nanny_read:
 

--- a/arc_application/tests/test_arc_user_summary.py
+++ b/arc_application/tests/test_arc_user_summary.py
@@ -67,35 +67,35 @@ class ArcUserSummaryPageTests(TestCase):
     # Integration level tests #
     # ----------------------- #
 
-    @tag('integration')
-    def test_list_nanny_tasks_to_review(self):
-        """
-        Test that the _list_tasks_for_review() method returns a complete list of tasks for review.
-
-        If we were to mock the Gateway response, this test will continue to pass even if the models are updated.
-        Must therefore be an integration test.
-        """
-        test_uuid = str(uuid4())
-        NannyGatewayActions().create('application', params={'application_id': test_uuid})
-        tasks_list = NannyApplicationHandler(arc_user=self.user)._list_tasks_for_review()
-
-        expected_list = [
-            'login_details',
-            'personal_details',
-            'childcare_address',
-            'first_aid_training',
-            'childcare_training',
-            'criminal_record_check',
-            'dbs',
-            'first_aid',
-            'insurance_cover',
-            'your_children'
-        ]
-
-        for task in tasks_list:
-            self.assertIn(task, expected_list)
-
-        NannyGatewayActions().delete('application', params={'application_id': test_uuid})
+    # @tag('integration')
+    # def test_list_nanny_tasks_to_review(self):
+    #     """
+    #     Test that the _list_tasks_for_review() method returns a complete list of tasks for review.
+    #
+    #     If we were to mock the Gateway response, this test will continue to pass even if the models are updated.
+    #     Must therefore be an integration test.
+    #     """
+    #     test_uuid = str(uuid4())
+    #     NannyGatewayActions().create('application', params={'application_id': test_uuid})
+    #     tasks_list = NannyApplicationHandler(arc_user=self.user)._list_tasks_for_review()
+    #
+    #     expected_list = [
+    #         'login_details',
+    #         'personal_details',
+    #         'childcare_address',
+    #         'first_aid_training',
+    #         'childcare_training',
+    #         'criminal_record_check',
+    #         'dbs',
+    #         'first_aid',
+    #         'insurance_cover',
+    #         'your_children'
+    #     ]
+    #
+    #     for task in tasks_list:
+    #         self.assertIn(task, expected_list)
+    #
+    #     NannyGatewayActions().delete('application', params={'application_id': test_uuid})
 
     # ---------------- #
     # HTTP level tests #

--- a/arc_application/views/arc_user_summary.py
+++ b/arc_application/views/arc_user_summary.py
@@ -19,10 +19,7 @@ class ARCUserSummaryView(View):
 
     def post(self, request):
 
-        if 'add_nanny_application' in request.POST:
-            app_handler = NannyApplicationHandler(arc_user=request.user)
-
-        elif 'add_childminder_application' in request.POST:
+        if 'add_childminder_application' in request.POST:
             app_handler = ChildminderApplicationHandler(arc_user=request.user)
 
         try:
@@ -45,7 +42,7 @@ class ARCUserSummaryView(View):
 
     def get_context_data(self):
         context = dict()
-        context['entries'] = GenericApplicationHandler(arc_user=self.request.user).get_all_table_data()
+        context['entries'] = ChildminderApplicationHandler(arc_user=self.request.user).get_all_table_data()
 
         if not len(context['entries']):
             context['empty'] = 'true'


### PR DESCRIPTION
## Description

Removed functionality relating to Nannies from the Arc review summary page.
This should be merged into the release branch for the Childminder Service Launch.

## Todo's before PR

- [ ] Rebase from develop
- [ ] Unit tests passed (`make test`)
- [ ] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates been checked with relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assigneses (those who'll merge)
- [ ] Specified labels
- [ ] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
