### PR TITLE
fix "Enhanced DBS Check?" flag on childminder PITH review page

### DIFF
--- a/arc_application/forms/childminder_forms/form.py
+++ b/arc_application/forms/childminder_forms/form.py
@@ -1106,6 +1106,7 @@ class AdultInYourHomeForm(GOVUKForm):
             ((self.fields['relationship_declare']), 'relationship' + id_value),
             ((self.fields['email_declare']), 'email' + id_value),
             ((self.fields['dbs_certificate_number_declare']), 'dbs_certificate_number' + id_value),
+            ((self.fields['enhanced_check_declare']), 'enhanced_check' + id_value),
             ((self.fields['on_update_declare']), 'on_update' + id_value),
             ((self.fields['lived_abroad_declare']), 'lived_abroad' + id_value),
             ((self.fields['military_base_declare']), 'military_base' + id_value),

--- a/arc_application/templates/childminder_templates/other-people-summary.html
+++ b/arc_application/templates/childminder_templates/other-people-summary.html
@@ -386,7 +386,7 @@
                     {{ formsetadult.enhanced_check_declare }}
                 </td>
             </tr>
-            <tr class="js-hidden" id="capita{{formsetadult.instance_id.initial}}">
+            <tr class="js-hidden" id="enhanced_check{{formsetadult.instance_id.initial}}">
                 <td colspan="1">
                     <div>
                         Enter your reasoning


### PR DESCRIPTION
## Description

Fixes bug preventing Enhanced Check field from being flagged on childminder people-in-the-home review page

## Todo's before PR

- [ ] Rebase from develop
- [ ] Unit tests passed (`make test`)
- [ ] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates been checked with relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assigneses (those who'll merge)
- [ ] Specified labels
- [ ] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
