### PR TITLE
Fix/error template resolution

### DIFF
--- a/arc_application/forms/childminder_forms/form.py
+++ b/arc_application/forms/childminder_forms/form.py
@@ -554,7 +554,7 @@ class PreviousRegistrationDetailsForm(GOVUKForm):
     """
     GOV.UK form for adding details of previous registration
     """
-    error_summary_template_name = 'standard-error-summary.html'
+    error_summary_template_name = 'childminder_templates/standard-error-summary.html'
     error_summary_title = 'There was a problem on this page'
     field_label_classes = 'form-label-bold'
     auto_replace_widgets = True
@@ -567,7 +567,7 @@ class PreviousRegistrationDetailsForm(GOVUKForm):
 
     previous_registration = forms.ChoiceField(choices=choices,
                                               label='Has the applicant previously registered with Ofsted?',
-                                              widget=InlineRadioSelect, required=True,
+                                              widget=ConditionalPostInlineRadioSelect, required=True,
                                               error_messages={'required': "Please select one"})
     custom_number_input = NumberInput()
     custom_number_input.input_classes = 'form-control form-control-1-4'
@@ -597,7 +597,7 @@ class PreviousRegistrationDetailsForm(GOVUKForm):
             individual_id = None
         if previous_registration == 'True':
             if individual_id is None:
-                raise forms.ValidationError("Please select one")
+                raise forms.ValidationError("Please enter an Individual ID")
             if len(str(individual_id)) > 7:
                 raise forms.ValidationError("Individual ID must be fewer than 7 digits")
         return individual_id
@@ -1930,7 +1930,7 @@ class OtherPersonPreviousRegistrationDetailsForm(GOVUKForm):
     """
     GOV.UK form for adding details of previous registration.
     """
-    error_summary_template_name = 'standard-error-summary.html'
+    error_summary_template_name = 'childminder_templates/standard-error-summary.html'
     error_summary_title = 'There was a problem on this page'
     field_label_classes = 'form-label-bold'
     auto_replace_widgets = True
@@ -1973,7 +1973,7 @@ class OtherPersonPreviousRegistrationDetailsForm(GOVUKForm):
             individual_id = None
         if previous_registration == 'True':
             if individual_id is None:
-                raise forms.ValidationError("Please select one")
+                raise forms.ValidationError("Please enter an Individual ID")
             if len(str(individual_id)) > 7:
                 raise forms.ValidationError("Individual ID must be fewer than 7 digits")
         return individual_id

--- a/arc_application/static/stylesheets/custom.css
+++ b/arc_application/static/stylesheets/custom.css
@@ -425,7 +425,3 @@
       width: 100%;
     }
 }
-
-#id_individual_id-group {
-    margin-bottom: 15px;
-}

--- a/arc_application/static/stylesheets/custom.css
+++ b/arc_application/static/stylesheets/custom.css
@@ -425,3 +425,7 @@
       width: 100%;
     }
 }
+
+#id_individual_id-group {
+    margin-bottom: 15px;
+}


### PR DESCRIPTION
## Description

Fix for error summary oath resolution on the Previous Registration page. Adjusts field location of Individual ID text box to be consistent with that shown for other people in the home.

Updates error text in scenario an individual id is not provided.

## Todo's before PR

- [x] Rebase from develop
- [x] Unit tests passed (`make test`)
- [x] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [ ] Templates been checked with relevant user-story

## Migrations

- [x] Null fields in models specifies default value
- [x] You generated and applied migrations (`make migrate`)
- [x] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assigneses (those who'll merge)
- [x] Specified labels
- [ ] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
