### PR TITLE
Fix to export previous registrations of adults in the home

### DIFF
--- a/arc_application/messaging/application_exporter.py
+++ b/arc_application/messaging/application_exporter.py
@@ -3,10 +3,10 @@ import json
 from django.conf import settings
 from django.core import serializers
 
-from ..models import Application, ApplicantName, ApplicantHomeAddress, ApplicantPersonalDetails,  AdultInHome, \
+from ..models import Application, ApplicantName, ApplicantHomeAddress, ApplicantPersonalDetails, AdultInHome, \
     ChildInHome, PreviousName, PreviousAddress, HealthCheckHospital, HealthCheckSerious, HealthCheckCurrent, \
     CriminalRecordCheck, ChildcareType, ChildcareTraining, FirstAidTraining, HealthDeclarationBooklet, \
-    PreviousRegistrationDetails, Reference, UserDetails
+    PreviousRegistrationDetails, Reference, UserDetails, OtherPersonPreviousRegistrationDetails
 
 from .document_generator import DocumentGenerator
 
@@ -44,11 +44,13 @@ class ApplicationExporter:
             serious_illness = HealthCheckSerious.objects.filter(person_id=adult_in_home.pk)
             hospital_admissions = HealthCheckHospital.objects.filter(person_id=adult_in_home.pk)
             current_illnesses = HealthCheckCurrent.objects.filter(person_id=adult_in_home.pk)
+            previous_registrations = OtherPersonPreviousRegistrationDetails.objects.filter(person_id_id=adult_in_home.pk)
 
             adults_in_home_export.append({
                 'adult': adult_in_home.adult,
                 'previous_names': serializers.serialize('json', list(previous_name)),
                 'previous_address': serializers.serialize('json', list(previous_address)),
+                'previous_registrations': serializers.serialize('json', list(previous_registrations)),
                 'serious_illness': serializers.serialize('json', list(serious_illness)),
                 'hospital_admissions': serializers.serialize('json', list(hospital_admissions)),
                 'current_illnesses': serializers.serialize('json', list(current_illnesses))


### PR DESCRIPTION
## Description

Adds export of previous registrations for adults in the home.

## Todo's before PR

- [x] Rebase from develop
- [x] Unit tests passed (`make test`)
- [ ] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates been checked with relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assigneses (those who'll merge)
- [x] Specified labels
- [ ] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
