### PR TITLE
fix/CM-adult-in-home-previous-names-addresses

### DIFF
--- a/arc_application/fixtures/test_application_with_adults.json
+++ b/arc_application/fixtures/test_application_with_adults.json
@@ -151,13 +151,6 @@
  }
 },
 {
- "model": "arc_application.applicationreference",
- "pk": 1,
- "fields": {
-  "reference": 1000000
- }
-},
-{
  "model": "arc_application.childcaretype",
  "pk": "a3fd928c-6cc4-44bf-b176-08b07d90c056",
  "fields": {

--- a/arc_application/models/adult_in_home.py
+++ b/arc_application/models/adult_in_home.py
@@ -182,24 +182,29 @@ class AdultInHome(models.Model):
 
         # late import to avoid circular dependency
         from .previous_name import PreviousName
+        from .previous_address import PreviousAddress
+        from arc_application.views.childminder_views.childminder_utils import render_previous_name
+        from arc_application.views.childminder_views.childminder_utils import render_previous_address
 
         previous_names = PreviousName.objects.filter(person_id=self.pk, other_person_type='ADULT').order_by('order')
-        if len(previous_names) == 0:
+        previous_addresses = PreviousAddress.objects.filter(person_id=self.pk, person_type='ADULT').order_by('order')
+
+        if len(previous_names) == 0 and len(previous_addresses) == 0:
             return None
 
         summary_table = [
             {"title": "{}'s previous names and addresses".format(self.get_full_name()),
              "id": self.pk}
         ]
-        for i, name in enumerate(previous_names):
-            summary_table.extend([
-                {"name": "Previous name {}".format(i + 1),
-                 "value": name.name},
-                {"name": "Start date",
-                 "value": name.start_date.strftime("%d %B %Y") if name.start_date else ''},
-                {"name": "End date",
-                 "value": name.end_date.strftime("%d %B %Y") if name.end_date else ''},
-            ])
+
+        if len(previous_names) != 0:
+            for i, name in enumerate(previous_names):
+                summary_table.extend(render_previous_name(name, i + 1))
+
+        if len(previous_addresses) != 0:
+            for i, address in enumerate(previous_addresses):
+                summary_table.extend(render_previous_address(address, i + 1))
+
         return summary_table
 
     def show_enhanced_check(self):


### PR DESCRIPTION
## Description

Updated CM master_summary and cc_summary to include previous names and address tables for adults in the home.

## Todo's before PR

- [ ] Rebase from develop
- [ ] Unit tests passed (`make test`)
- [ ] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates been checked with relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assigneses (those who'll merge)
- [ ] Specified labels
- [ ] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
