### PR TITLE
fix/CCN3-2431/multiple-submission-on-refresh

### DIFF
--- a/arc_application/fixtures/test_application_with_adults.json
+++ b/arc_application/fixtures/test_application_with_adults.json
@@ -133,9 +133,7 @@
   "country": "",
   "postcode": "WA14 4PA",
   "childcare_address": true,
-  "current_address": true,
-  "move_in_month": 0,
-  "move_in_year": 0
+  "current_address": true
  }
 },
 {

--- a/arc_application/tests/test_childminder_review/test_routing.py
+++ b/arc_application/tests/test_childminder_review/test_routing.py
@@ -1,8 +1,9 @@
 import logging
 from datetime import datetime, timezone, date
-from unittest.mock import patch
 from unittest import skip
+from unittest.mock import patch
 
+import pytz
 from django.test import TestCase, tag
 from django.urls import reverse
 
@@ -306,19 +307,19 @@ class ApplicantPreviousNamesFunctionalTests(TestCase):
         self.assertEqual(200, response.status_code)
 
         for field, ftype, value in [
-                ('form-1-first_name', 'text', 'Clark'), ('form-0-first_name', 'text', 'Super'),
-                ('form-1-middle_names', 'text', 'S'), ('form-0-middle_names', 'text', ''),
-                ('form-1-last_name', 'text', 'Kent'), ('form-0-last_name', 'text', 'Man'),
-                ('form-1-start_date_0', 'number', '1'), ('form-0-start_date_0', 'number', '2'),
-                ('form-1-start_date_1', 'number', '1'), ('form-0-start_date_1', 'number', '2'),
-                ('form-1-start_date_2', 'number', '2018'), ('form-0-start_date_2', 'number', '2015'),
-                ('form-1-end_date_0', 'number', '1'), ('form-0-end_date_0', 'number', '1'),
-                ('form-1-end_date_1', 'number', '1'), ('form-0-end_date_1', 'number', '1'),
-                ('form-1-end_date_2', 'number', '2019'), ('form-0-end_date_2', 'number', '2017')]:
+            ('form-1-first_name', 'text', 'Clark'), ('form-0-first_name', 'text', 'Super'),
+            ('form-1-middle_names', 'text', 'S'), ('form-0-middle_names', 'text', ''),
+            ('form-1-last_name', 'text', 'Kent'), ('form-0-last_name', 'text', 'Man'),
+            ('form-1-start_date_0', 'number', '1'), ('form-0-start_date_0', 'number', '2'),
+            ('form-1-start_date_1', 'number', '1'), ('form-0-start_date_1', 'number', '2'),
+            ('form-1-start_date_2', 'number', '2018'), ('form-0-start_date_2', 'number', '2015'),
+            ('form-1-end_date_0', 'number', '1'), ('form-0-end_date_0', 'number', '1'),
+            ('form-1-end_date_1', 'number', '1'), ('form-0-end_date_1', 'number', '1'),
+            ('form-1-end_date_2', 'number', '2019'), ('form-0-end_date_2', 'number', '2017')]:
             utils.assertXPathValue(
                 response,
                 'string(//input[normalize-space(@type)="{ftype}" and normalize-space(@name)="{field}"]/@value)'
-                .format(field=field, ftype=ftype),
+                    .format(field=field, ftype=ftype),
                 value,
                 strip=True
             )
@@ -577,7 +578,7 @@ class ApplicantPreviousNamesFunctionalTests(TestCase):
         data.update(self.valid_previous_name_data[1])
         data['form-0-previous_name_id'] = name1.pk
         data['form-1-previous_name_id'] = name2.pk
-        data['delete-'+str(name1.pk)] = 'Remove this name'
+        data['delete-' + str(name1.pk)] = 'Remove this name'
 
         # Follow redirects to land on target page
         response = self.client.post(url, data, follow=True)
@@ -647,7 +648,7 @@ class ApplicantPreviousNamesFunctionalTests(TestCase):
         data.update(self.valid_previous_name_data[1])
         data['form-0-previous_name_id'] = name1.pk
         data['form-1-previous_name_id'] = name2.pk
-        data['delete-'+str(name1.pk)] = 'Remove this name'
+        data['delete-' + str(name1.pk)] = 'Remove this name'
 
         url = '{0}?id={1}&person_id={1}&type=APPLICANT'.format(reverse('personal_details_previous_names'),
                                                                self.application.pk)
@@ -679,13 +680,14 @@ class ApplicantPreviousNamesFunctionalTests(TestCase):
             'person_id': self.application.pk,
             'type': 'APPLICANT',
             'form-TOTAL_FORMS': num_names,
-            'form-INITIAL_FORMS': num_names-1 if last_is_new else num_names,
+            'form-INITIAL_FORMS': num_names - 1 if last_is_new else num_names,
             'form-MIN_NUM_FORMS': 0,
             'form-MAX_NUM_FORMS': 1000,
         }
         if action is not None:
             data['action'] = action
         return data
+
 
 @skip('functionalityNotImplemented')
 @tag('http')
@@ -751,7 +753,7 @@ class ApplicantPreviousAddressesFunctionalTests(TestCase):
             person_id=application_id,
             other_person_type='APPLICANT',
             street_line1='Informed', street_line2='Manchester Road', town='Altrincham',
-            county = 'Greater Manchester', postcode = 'WA14 4PA',
+            county='Greater Manchester', postcode='WA14 4PA',
             moved_in_day=1, moved_in_month=1, moved_in_year=2018,
             moved_out_day=1, moved_out_month=1, moved_out_year=2019
         )
@@ -759,7 +761,7 @@ class ApplicantPreviousAddressesFunctionalTests(TestCase):
             person_id=application_id,
             other_person_type='APPLICANT',
             street_line1='Fortis', street_line2='Manchester Road', town='Altrincham',
-            county = 'Greater Manchester', postcode = 'WA14 4PA',
+            county='Greater Manchester', postcode='WA14 4PA',
             moved_in_day=1, moved_in_month=1, moved_in_year=2019,
             moved_out_day=15, moved_out_month=3, moved_out_year=2019
         )
@@ -772,12 +774,17 @@ class ApplicantPreviousAddressesFunctionalTests(TestCase):
         self.assertEqual(200, response.status_code)
 
         for addresses in [
-            ('Informed', 'Manchester Road', 'Altrincham', 'Greater Manchester', 'WA14 4PA' '1', '1', '2018', '1', '1', '2019'),
-            ('Fortis', 'Manchester Road', 'Altrincham', 'Greater Manchester', 'WA14 4PA' '1', '1', '2019', '15', '3', '2019')]:
-            for field, address in [('street_line1', addresses[0]), ('street_line2', addresses[1]), ('town', addresses[2]),
-                                     ('county', addresses[3]), ('postcode', addresses[4]),
-                                ('moved_in_date_0', addresses[5]), ('moved_in_date_1', addresses[6]), ('moved_in_date_2', addresses[7]),
-                                ('moved_out_date_0', addresses[8]), ('moved_out_date_1', addresses[9]), ('moved_out_date_2', addresses[10])]:
+            ('Informed', 'Manchester Road', 'Altrincham', 'Greater Manchester', 'WA14 4PA' '1', '1', '2018', '1', '1',
+             '2019'),
+            ('Fortis', 'Manchester Road', 'Altrincham', 'Greater Manchester', 'WA14 4PA' '1', '1', '2019', '15', '3',
+             '2019')]:
+            for field, address in [('street_line1', addresses[0]), ('street_line2', addresses[1]),
+                                   ('town', addresses[2]),
+                                   ('county', addresses[3]), ('postcode', addresses[4]),
+                                   ('moved_in_date_0', addresses[5]), ('moved_in_date_1', addresses[6]),
+                                   ('moved_in_date_2', addresses[7]),
+                                   ('moved_out_date_0', addresses[8]), ('moved_out_date_1', addresses[9]),
+                                   ('moved_out_date_2', addresses[10])]:
                 utils.assertXPath(
                     response,
                     ('//input[normalize-space(@type)="text" and contains(normalize-space(@address), "{field}") '
@@ -1583,19 +1590,19 @@ class AdultPreviousNamesFunctionalTests(TestCase):
         self.assertEqual(200, response.status_code)
 
         for field, ftype, value in [
-                ('form-1-first_name', 'text', 'Fresh'), ('form-0-first_name', 'text', 'Will'),
-                ('form-1-middle_names', 'text', 'Prince'), ('form-0-middle_names', 'text', ''),
-                ('form-1-last_name', 'text', 'Belair'), ('form-0-last_name', 'text', 'Smith'),
-                ('form-1-start_date_0', 'number', '1'), ('form-0-start_date_0', 'number', '9'),
-                ('form-1-start_date_1', 'number', '10'), ('form-0-start_date_1', 'number', '4'),
-                ('form-1-start_date_2', 'number', '1999'), ('form-0-start_date_2', 'number', '2015'),
-                ('form-1-end_date_0', 'number', '10'), ('form-0-end_date_0', 'number', '3'),
-                ('form-1-end_date_1', 'number', '11'), ('form-0-end_date_1', 'number', '12'),
-                ('form-1-end_date_2', 'number', '2007'), ('form-0-end_date_2', 'number', '2016')]:
+            ('form-1-first_name', 'text', 'Fresh'), ('form-0-first_name', 'text', 'Will'),
+            ('form-1-middle_names', 'text', 'Prince'), ('form-0-middle_names', 'text', ''),
+            ('form-1-last_name', 'text', 'Belair'), ('form-0-last_name', 'text', 'Smith'),
+            ('form-1-start_date_0', 'number', '1'), ('form-0-start_date_0', 'number', '9'),
+            ('form-1-start_date_1', 'number', '10'), ('form-0-start_date_1', 'number', '4'),
+            ('form-1-start_date_2', 'number', '1999'), ('form-0-start_date_2', 'number', '2015'),
+            ('form-1-end_date_0', 'number', '10'), ('form-0-end_date_0', 'number', '3'),
+            ('form-1-end_date_1', 'number', '11'), ('form-0-end_date_1', 'number', '12'),
+            ('form-1-end_date_2', 'number', '2007'), ('form-0-end_date_2', 'number', '2016')]:
             utils.assertXPathValue(
                 response,
                 'normalize-space(//input[normalize-space(@type)="{ftype}" and normalize-space(@name)="{field}"]/@value)'
-                .format(field=field, ftype=ftype),
+                    .format(field=field, ftype=ftype),
                 value,
             )
 
@@ -1628,7 +1635,7 @@ class AdultPreviousNamesFunctionalTests(TestCase):
         )
 
         url = reverse('other-people-previous-names') \
-            + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
+              + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
 
         data = self._make_post_data(2, 'Confirm and continue', last_is_new=True)
         data.update(self.valid_names_post_data[0])
@@ -1657,7 +1664,7 @@ class AdultPreviousNamesFunctionalTests(TestCase):
         )
 
         url = reverse('other-people-previous-names') \
-            + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
+              + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
 
         data = self._make_post_data(2, 'Confirm and continue', last_is_new=True)
         data.update(self.valid_names_post_data[0])
@@ -1683,7 +1690,7 @@ class AdultPreviousNamesFunctionalTests(TestCase):
         )
 
         url = reverse('other-people-previous-names') \
-            + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
+              + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
 
         data = self._make_post_data(2, 'Confirm and continue', last_is_new=True)
         data.update(self.valid_names_post_data[0])
@@ -1728,7 +1735,7 @@ class AdultPreviousNamesFunctionalTests(TestCase):
         )
 
         url = reverse('other-people-previous-names') \
-            + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
+              + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
         data = self._make_post_data(1, 'Add another name')
         data.update(self.valid_names_post_data[0])
 
@@ -1830,14 +1837,14 @@ class AdultPreviousNamesFunctionalTests(TestCase):
         )
 
         url = reverse('other-people-previous-names') \
-            + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
+              + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
 
         data = self._make_post_data(2)
         data.update(self.valid_names_post_data[0])
         data.update(self.valid_names_post_data[1])
         data['form-0-previous_name_id'] = name1.pk
         data['form-1-previous_name_id'] = name2.pk
-        data['delete-'+str(name1.pk)] = 'Remove this name'
+        data['delete-' + str(name1.pk)] = 'Remove this name'
 
         # follow redirects to land on target page
         response = self.client.post(url, data, follow=True)
@@ -1906,7 +1913,7 @@ class AdultPreviousNamesFunctionalTests(TestCase):
         data.update(self.valid_names_post_data[1])
         data['form-0-previous_name_id'] = name1.pk
         data['form-1-previous_name_id'] = name2.pk
-        data['delete-'+str(name1.pk)] = 'Remove this name'
+        data['delete-' + str(name1.pk)] = 'Remove this name'
 
         url = reverse('other-people-previous-names') \
               + '?id={}&person_id={}&type={}'.format(self.application.pk, self.adult.pk, 'ADULT')
@@ -1939,7 +1946,7 @@ class AdultPreviousNamesFunctionalTests(TestCase):
             'person_id': self.adult.pk,
             'type': 'ADULT',
             'form-TOTAL_FORMS': num_names,
-            'form-INITIAL_FORMS': num_names-1 if last_is_new else num_names,
+            'form-INITIAL_FORMS': num_names - 1 if last_is_new else num_names,
             'form-MIN_NUM_FORMS': 0,
             'form-MAX_NUM_FORMS': 1000,
         }
@@ -2284,7 +2291,7 @@ class ReviewSummaryAndConfirmationFunctionalTests(TestCase):
             other_person_type='ADULT',
             first_name='Tina', middle_names='T', last_name='Tuna',
             start_day=8, start_month=9, start_year=2001,
-            end_day=1,  end_month=1, end_year=2002,
+            end_day=1, end_month=1, end_year=2002,
             order=0,
         )
 
@@ -2309,7 +2316,7 @@ class ReviewSummaryAndConfirmationFunctionalTests(TestCase):
     class MockDatetime(datetime):
         @classmethod
         def now(cls):
-            return datetime(2019, 2, 27, 17, 30, 5)
+            return datetime(2019, 2, 27, 17, 30, 5, tzinfo=pytz.UTC)
 
     @patch('arc_application.messaging.application_exporter.ApplicationExporter.export_childminder_application')
     @patch('arc_application.messaging.application_exporter.ApplicationExporter.export_nanny_application')

--- a/arc_application/tests/test_childminder_review/test_routing.py
+++ b/arc_application/tests/test_childminder_review/test_routing.py
@@ -2418,3 +2418,6 @@ class ReviewSummaryAndConfirmationFunctionalTests(TestCase):
             self.assertEqual(ARC_STATUS_FLAGGED, getattr(refetched_arc, '{}_review'.format(task)))
         for task in ARC_TASKS_UNFLAGGED:
             self.assertEqual(ARC_STATUS_COMPLETED, getattr(refetched_arc, '{}_review'.format(task)))
+
+    def test_submit_releases_application_once_if_submitted_twice(self):
+        self.skipTest("testNotImplemented")

--- a/arc_application/tests/test_nanny_review/test_routing.py
+++ b/arc_application/tests/test_nanny_review/test_routing.py
@@ -233,7 +233,6 @@ class ReviewPersonalDetailsTests(NannyReviewFuncTestsBase):
         self.assertEqual(response.status_code, 302)
 
     def test_shows_Add_Previous_Names_button(self):
-
         # GET request to personal details summary
         response = self.client.get(reverse('nanny_personal_details_summary') + '?id=' + self.test_app_id)
 
@@ -242,7 +241,6 @@ class ReviewPersonalDetailsTests(NannyReviewFuncTestsBase):
             url=reverse('nanny_previous_names'), app_id=self.test_app_id))
 
     def test_shows_previous_names_in_creation_order(self):
-
         self.nanny_gateway.previous_name_list_response = self.nanny_gateway.make_response(record=[
             self.nanny_gateway.previous_name_record,
             {
@@ -378,9 +376,9 @@ class NannyPreviousNamesTests(NannyReviewFuncTestsBase):
                 'application_id': '998fd8ec-b96b-4a71-a1a1-a7a3ae186729',
                 'previous_name_id': '9935bf3b-8ba9-4162-a25b-4c55e7d33d67',
                 'first_name': 'Buffy',
-                'middle_names':'',
+                'middle_names': '',
                 'last_name': 'Summers',
-                'start_day':3,
+                'start_day': 3,
                 'start_month': 12,
                 'start_year': 2004,
                 'end_day': 7,
@@ -400,19 +398,19 @@ class NannyPreviousNamesTests(NannyReviewFuncTestsBase):
             self.assertEqual(200, response.status_code)
 
             for field, ftype, value in [
-                    ('form-0-first_name', 'text', 'Robin'), ('form-1-first_name', 'text', 'Buffy'),
-                    ('form-0-middle_names', 'text', ''), ('form-1-middle_names', 'text', ''),
-                    ('form-0-last_name', 'text', 'Hood'), ('form-1-last_name', 'text', 'Summers'),
-                    ('form-0-start_date_0', 'number', '1'), ('form-1-start_date_0', 'number', '3'),
-                    ('form-0-start_date_1', 'number', '12'), ('form-1-start_date_1', 'number', '12'),
-                    ('form-0-start_date_2', 'number', '2003'), ('form-1-start_date_2', 'number', '2004'),
-                    ('form-0-end_date_0', 'number', '3'), ('form-1-end_date_0', 'number', '7'),
-                    ('form-0-end_date_1', 'number', '12'), ('form-1-end_date_1', 'number', '12'),
-                    ('form-0-end_date_2', 'number', '2004'), ('form-1-end_date_2', 'number', '2004')]:
+                ('form-0-first_name', 'text', 'Robin'), ('form-1-first_name', 'text', 'Buffy'),
+                ('form-0-middle_names', 'text', ''), ('form-1-middle_names', 'text', ''),
+                ('form-0-last_name', 'text', 'Hood'), ('form-1-last_name', 'text', 'Summers'),
+                ('form-0-start_date_0', 'number', '1'), ('form-1-start_date_0', 'number', '3'),
+                ('form-0-start_date_1', 'number', '12'), ('form-1-start_date_1', 'number', '12'),
+                ('form-0-start_date_2', 'number', '2003'), ('form-1-start_date_2', 'number', '2004'),
+                ('form-0-end_date_0', 'number', '3'), ('form-1-end_date_0', 'number', '7'),
+                ('form-0-end_date_1', 'number', '12'), ('form-1-end_date_1', 'number', '12'),
+                ('form-0-end_date_2', 'number', '2004'), ('form-1-end_date_2', 'number', '2004')]:
                 utils.assertXPathValue(
                     response,
                     'string(//input[normalize-space(@type)="{ftype}" and normalize-space(@name)="{field}"]/@value)'
-                    .format(field=field, ftype=ftype),
+                        .format(field=field, ftype=ftype),
                     value,
                     strip=True
                 )
@@ -449,7 +447,7 @@ class NannyPreviousNamesTests(NannyReviewFuncTestsBase):
                                   'end_month': 12,
                                   'end_year': 2004,
                                   'order': 1}
-            nanny_api_list.return_value.record = [ prev_name_record_2]
+            nanny_api_list.return_value.record = [prev_name_record_2]
 
             nanny_api_list.return_value.status_code = 200
             application_id = self.test_app_id
@@ -509,10 +507,9 @@ class NannyPreviousNamesTests(NannyReviewFuncTestsBase):
 
     def test_submit_confirm_calls_create_on_data_inputted(self):
 
-        with patch.object(NannyGatewayActions, 'list') as nanny_api_list,\
+        with patch.object(NannyGatewayActions, 'list') as nanny_api_list, \
                 patch.object(NannyGatewayActions, 'create') as nanny_api_create:
-
-            url = '{0}?id={1}'.format(reverse('nanny_previous_names'), self.test_app_id )
+            url = '{0}?id={1}'.format(reverse('nanny_previous_names'), self.test_app_id)
 
             data = self._make_post_data(2, 'Confirm and continue', last_is_new=True)
             data.update(self.valid_previous_name_data[0])
@@ -995,3 +992,9 @@ class ReviewSummaryAndConfirmationFunctionalTests(NannyReviewFuncTestsBase):
             self.assertEqual(ARC_STATUS_FLAGGED, getattr(refetched_arc, '{}_review'.format(task)))
         for task in ARC_TASKS_UNFLAGGED:
             self.assertEqual(ARC_STATUS_COMPLETED, getattr(refetched_arc, '{}_review'.format(task)))
+
+    @patch('arc_application.messaging.application_exporter.ApplicationExporter.export_childminder_application')
+    @patch('arc_application.messaging.application_exporter.ApplicationExporter.export_nanny_application')
+    @patch('datetime.datetime', new=MockDatetime)
+    def test_submit_releases_application_once_if_submitted_twice(self, mock_datetime, mock_export_nanny_application, _):
+        self.skipTest("testNotImplemented")

--- a/arc_application/tests/test_nanny_review/test_routing.py
+++ b/arc_application/tests/test_nanny_review/test_routing.py
@@ -993,8 +993,5 @@ class ReviewSummaryAndConfirmationFunctionalTests(NannyReviewFuncTestsBase):
         for task in ARC_TASKS_UNFLAGGED:
             self.assertEqual(ARC_STATUS_COMPLETED, getattr(refetched_arc, '{}_review'.format(task)))
 
-    @patch('arc_application.messaging.application_exporter.ApplicationExporter.export_childminder_application')
-    @patch('arc_application.messaging.application_exporter.ApplicationExporter.export_nanny_application')
-    @patch('datetime.datetime', new=MockDatetime)
-    def test_submit_releases_application_once_if_submitted_twice(self, mock_datetime, mock_export_nanny_application):
+    def test_submit_releases_application_once_if_submitted_twice(self):
         self.skipTest("testNotImplemented")

--- a/arc_application/tests/test_nanny_review/test_routing.py
+++ b/arc_application/tests/test_nanny_review/test_routing.py
@@ -996,5 +996,5 @@ class ReviewSummaryAndConfirmationFunctionalTests(NannyReviewFuncTestsBase):
     @patch('arc_application.messaging.application_exporter.ApplicationExporter.export_childminder_application')
     @patch('arc_application.messaging.application_exporter.ApplicationExporter.export_nanny_application')
     @patch('datetime.datetime', new=MockDatetime)
-    def test_submit_releases_application_once_if_submitted_twice(self, mock_datetime, mock_export_nanny_application, _):
+    def test_submit_releases_application_once_if_submitted_twice(self, mock_datetime, mock_export_nanny_application):
         self.skipTest("testNotImplemented")

--- a/arc_application/views/base.py
+++ b/arc_application/views/base.py
@@ -13,6 +13,8 @@ from django.shortcuts import render
 from django.utils.http import urlsafe_base64_decode
 from django.utils.text import capfirst
 
+import copy
+
 from govuk_forms.forms import GOVUKForm
 from timeline_logger.models import TimelineLog
 from ..review_util import reset_declaration
@@ -111,7 +113,7 @@ def release_application(request, application_id, status):
     if Application.objects.filter(application_id=application_id).exists():
 
         app = Application.objects.get(application_id=application_id)
-        APP_ORIGINAL = app.copy()
+        APP_ORIGINAL = copy.deepcopy(app)
 
         if status == 'FURTHER_INFORMATION':
             reset_declaration(app)

--- a/arc_application/views/nanny_views/nanny_arc_summary.py
+++ b/arc_application/views/nanny_views/nanny_arc_summary.py
@@ -49,10 +49,12 @@ class NannyArcSummary(View):
         no_flags_exist = nanny_all_completed(arc_application, application_id)
 
         if no_flags_exist:
-            send_accepted_email(**email_personalisation)
+            if nanny_application['application_status'] != 'ACCEPTED':
+                send_accepted_email(**email_personalisation)
             release_application(request, application_id, 'ACCEPTED')
         else:
-            send_returned_email(application_id, **email_personalisation)
+            if nanny_application['application_status'] != 'FURTHER_INFORMATION':
+                send_returned_email(application_id, **email_personalisation)
             release_application(request, application_id, 'FURTHER_INFORMATION')
 
         update_returned_application_statuses(application_id)


### PR DESCRIPTION
## Description

Fixed bug related to applications being resubmitted to Cygnum on page refresh, added skipTests for tests to be implemented in a future PR.

## Todo's before PR

- [ ] Rebase from develop
- [ ] Unit tests passed (`make test`)
- [ ] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates been checked with relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assigneses (those who'll merge)
- [ ] Specified labels
- [ ] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
