### PR TITLE
Remove postcode validation on previous addresses

### DIFF
--- a/arc_application/forms/previous_addresses.py
+++ b/arc_application/forms/previous_addresses.py
@@ -11,25 +11,12 @@ from .. import form_fields
 class PreviousAddressEntryForm(GOVUKForm):
 
     ERROR_MESSAGE_POSTCODE_NOT_ENTERED = 'Please enter your postcode'
-    ERROR_MESSAGE_POSTCODE_INVALID = 'Please enter a valid postcode'
 
     field_label_classes = 'form-label-bold'
     auto_replace_widgets = True
     error_summary_title = 'There was a problem'
 
     postcode = forms.CharField(label='Postcode', error_messages={'required': 'Please enter your postcode'})
-
-    def clean_postcode(self):
-        """
-        Postcode validation
-        :return: string
-        """
-        postcode = self.cleaned_data['postcode']
-        postcode_no_space = postcode.replace(" ", "")
-        postcode_uppercase = postcode_no_space.upper()
-        if re.match(settings.REGEX['POSTCODE_UPPERCASE'], postcode_uppercase) is None:
-            raise forms.ValidationError(self.ERROR_MESSAGE_POSTCODE_INVALID)
-        return postcode_uppercase
 
 
 class PreviousAddressSelectForm(GOVUKForm):
@@ -314,15 +301,3 @@ class PreviousAddressManualForm(GOVUKForm):
             if len(county) > 50:
                 raise forms.ValidationError(self.ERROR_MESSAGE_COUNTY_TOO_LONG)
         return county
-
-    def clean_postcode(self):
-        """
-        Postcode validation
-        :return: string
-        """
-        postcode = self.cleaned_data['postcode']
-        postcode_no_space = postcode.replace(" ", "")
-        postcode_uppercase = postcode_no_space.upper()
-        if re.match(settings.REGEX['POSTCODE_UPPERCASE'], postcode_uppercase) is None:
-            raise forms.ValidationError(self.ERROR_MESSAGE_POSTCODE_INVALID)
-        return postcode_uppercase

--- a/arc_application/tests/test_childminder_review/test_form_validation.py
+++ b/arc_application/tests/test_childminder_review/test_form_validation.py
@@ -339,7 +339,6 @@ class PersonalDetailsPreviousAddressEnterPostCodeFormValidationTests(TestCase):
     form = PreviousAddressEntryForm
 
     ERROR_MESSAGE_POSTCODE_NOT_ENTERED = 'Please enter your postcode'
-    ERROR_MESSAGE_POSTCODE_INVALID = 'Please enter a valid postcode'
 
     def test_invalid_when_no_postcode_entered(self):
         data = {
@@ -353,88 +352,6 @@ class PersonalDetailsPreviousAddressEnterPostCodeFormValidationTests(TestCase):
         self.assertEqual(form.errors, {
             'postcode': [self.ERROR_MESSAGE_POSTCODE_NOT_ENTERED]
         })
-
-    def test_invalid_when_postcode_random_characters(self):
-        data = {
-            'postcode': 'wEdsaKJ'
-        }
-        form = self.form(data)
-
-        self.assertFalse(form.is_valid())
-
-        # Check error messages
-        self.assertEqual(form.errors, {
-            'postcode': [self.ERROR_MESSAGE_POSTCODE_INVALID]
-        })
-
-    def test_invalid_when_postcode_numeric(self):
-        data = {
-            'postcode': '12468123'
-        }
-        form = self.form(data)
-
-        self.assertFalse(form.is_valid())
-
-        # Check error messages
-        self.assertEqual(form.errors, {
-            'postcode': [self.ERROR_MESSAGE_POSTCODE_INVALID]
-        })
-
-    def test_invalid_when_postcode_too_long(self):
-        data = {
-            'postcode': 'WA141RFD'
-        }
-        form = self.form(data)
-
-        self.assertFalse(form.is_valid())
-
-        # Check error messages
-        self.assertEqual(form.errors, {
-            'postcode': [self.ERROR_MESSAGE_POSTCODE_INVALID]
-        })
-
-    def test_invalid_when_postcode_too_short(self):
-        data = {
-            'postcode': 'WA1'
-        }
-        form = self.form(data)
-
-        self.assertFalse(form.is_valid())
-
-        # Check error messages
-        self.assertEqual(form.errors, {
-            'postcode': [self.ERROR_MESSAGE_POSTCODE_INVALID]
-        })
-
-    def test_valid_when_postcode_has_space_in_invalid_positions(self):
-        data = {
-            'postcode': 'WA1 41 R  F'
-        }
-        form = self.form(data)
-
-        self.assertTrue(form.is_valid())
-
-        # Assert that the cleaned postcode does not contain spaces
-        self.assertEqual(form.cleaned_data['postcode'], 'WA141RF')
-
-    def test_valid_when_postcode_entered_without_space(self):
-        data = {
-            'postcode': 'WA141RF'
-        }
-        form = self.form(data)
-
-        self.assertTrue(form.is_valid())
-
-    def test_valid_when_postcode_entered_lowercase(self):
-        data = {
-            'postcode': 'wa14 1rf'
-        }
-        form = self.form(data)
-
-        self.assertTrue(form.is_valid())
-
-        # Assert that the cleaned postcode is stored uppercase
-        self.assertEqual(form.cleaned_data['postcode'], 'WA141RF')
 
 
 @tag('unit')


### PR DESCRIPTION
Remove validation on previous address postcode values to permit international addresses to be added (based on testing feedback).

## Todo's before PR

- [x] Rebase from develop
- [ ] Unit tests passed (`make test`)
- [x] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates been checked with relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [x] Specified assigneses (those who'll merge)
- [x] Specified labels
- [ ] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
